### PR TITLE
SMCC-428 remove cluster member from service entry when connection drops

### DIFF
--- a/packages/happn-cluster/README.md
+++ b/packages/happn-cluster/README.md
@@ -74,7 +74,7 @@ var defaultConfig = {
             stabiliseTimeout: 15e3,
             keepAlive: 5e3,
             memberRefresh: 5e3,
-            health: 10e3
+            healthReport: 10e3
           },
           cluster: {
             'happn-cluster-node': 1
@@ -209,7 +209,7 @@ This is used as a part of the path where the keepalives are stored and looked up
 Array of happn paths or path masks that will be replicated throughout the cluster.
 
 #### config.timing:
-Contians the timing for variables related to membership, keepAlives,stabilisation, and health reporting
+Contains the timing for variables related to membership, keepAlives,stabilisation, and health reporting
 **NB.** These keepAlive ,keepAliveThreshold, and memberRefresh are set fairly long (around 5 seconds) by default, for regular use.  For testing purposes, it is recommended to shorten them as required, as well as config.keepAliveThreshold (above)  
 
 ##### config.timing.stabiliseTimeout
@@ -228,7 +228,7 @@ This should be set to slightly longer than the keepAlive timing above
 How often the node requests member list from DB, and then updates, connects and subscribes as required.
 
 ##### config.timing.healthReport: 
-How often the node reports it's health. The health report includes the node's state, and a list of how many peers of each service it has and expects.
+How often the node reports its health. The health report includes the node's state, and a list of how many peers of each service it has and expects.
 It will also log a JSON which has the following structure:
 ```
       {

--- a/packages/happn-cluster/lib/services/orchestrator.js
+++ b/packages/happn-cluster/lib/services/orchestrator.js
@@ -251,7 +251,7 @@ module.exports = class Orchestrator extends EventEmitter {
   removePeer(member) {
     member.listedAsPeer = false;
     this.emit('peer/remove', member.name, member);
-
+    this.removeMember(member);
     this.log.info('cluster size %d (%s left)', Object.keys(this.peers).length, member.name);
   }
 

--- a/packages/happner-cluster/test/_lib/helpers/muliProcessClusterManager.js
+++ b/packages/happner-cluster/test/_lib/helpers/muliProcessClusterManager.js
@@ -1,0 +1,72 @@
+const Helper = require('./helper');
+let ChildProcess = require('child_process');
+
+module.exports = class Cluster extends Helper {
+  constructor() {
+    super();
+    this.childProcess = {};
+
+    this.start = (configuration) => {
+      return new Promise((resolve, reject) => {
+        let childProcess = ChildProcess.fork(`${__dirname}/multiProcessClusterInstance.js`, [
+          JSON.stringify(configuration),
+        ]);
+        this.childProcess[childProcess.pid] = childProcess;
+        childProcess.on('message', function (message) {
+          if (message === 'ready') return resolve(childProcess);
+        });
+        childProcess.on('error', (cdoe) => {
+          this.removeChildProcess(childProcess);
+          reject(cdoe);
+        });
+        childProcess.on('exit', (code) => {
+          console.log(`child process exited with code ${code}`);
+          this.removeChildProcess(childProcess);
+        });
+      });
+    };
+    this.removeChildProcess = (childProcess) => {
+      childProcess.removeAllListeners('error');
+      childProcess.removeAllListeners('message');
+      childProcess.removeAllListeners('exit');
+      delete this.childProcess[childProcess.pid];
+    };
+    this.stopMesh = async (timeOut) => {
+      Object.values(this.childProcess).forEach((process) => {
+        process.send('stopMesh');
+      });
+      const timeOutTimestamp = Date.now() + timeOut;
+      while (Date.now() < timeOutTimestamp) {
+        await this.delay(100);
+        if (Object.keys(this.childProcess).length === 0) return true;
+      }
+      return false;
+    };
+    this.stopAllProcess = async (timeOut) => {
+      Object.values(this.childProcess).forEach((process) => {
+        process.kill('SIGTERM');
+      });
+      const timeOutTimestamp = Date.now() + timeOut;
+      while (Date.now() < timeOutTimestamp) {
+        await this.delay(100);
+        if (Object.keys(this.childProcess).length === 0) return;
+      }
+      console.warn(`Child process failed to respond to SIGTERM in ${timeOut}ms sending SIGKILL`);
+      Object.values(this.childProcess).forEach((process) => {
+        process.kill('SIGKILL');
+      });
+    };
+    this.destroy = async (timeOut = 5000) => {
+      const meshStopped = await this.stopMesh(timeOut);
+      if (meshStopped) return;
+      console.warn(
+        `Child process failed to respond to stopMesh in ${timeOut}ms, stopping processes`
+      );
+      return this.stopAllProcess(timeOut);
+    };
+  }
+
+  static create() {
+    return new Cluster();
+  }
+};

--- a/packages/happner-cluster/test/_lib/helpers/multiProcessClusterInstance.js
+++ b/packages/happner-cluster/test/_lib/helpers/multiProcessClusterInstance.js
@@ -1,0 +1,22 @@
+const HappnerCluster = require('../../..');
+var config = JSON.parse(process.argv[2]);
+let meshInstance = null;
+
+HappnerCluster.create(config)
+  .then(function (instance) {
+    meshInstance = instance;
+    if (typeof process.send === 'function') process.send('ready');
+  })
+  .catch(function () {
+    if (typeof process.send === 'function') process.send('error');
+    process.exit(1);
+  });
+
+process.on('message', async (m) => {
+  if (m === 'stopMesh') {
+    if (meshInstance) {
+      await meshInstance.stop();
+    }
+    process.exit(0);
+  }
+});

--- a/packages/happner-cluster/test/_lib/integration-37-broker-component/index.js
+++ b/packages/happner-cluster/test/_lib/integration-37-broker-component/index.js
@@ -1,0 +1,19 @@
+module.exports = Component;
+
+function Component() {}
+
+Component.prototype.start = function ($happn, callback) {
+  callback();
+};
+
+Component.prototype.stop = function ($happn, callback) {
+  callback();
+};
+
+Component.prototype.block = function ($happn, callback) {
+  setTimeout(() => {
+    const target = Date.now() + 10000;
+    while (Date.now() <= target) {}
+  }, 100);
+  callback(null, $happn.info.mesh.name + ':brokerComponent:block');
+};

--- a/packages/happner-cluster/test/_lib/integration-37-broker-component/package.json
+++ b/packages/happner-cluster/test/_lib/integration-37-broker-component/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "broker-component",
+  "version": "1.0.1",
+  "happner": {
+    "dependencies": {
+      "$broker": {
+        "remoteComponent": {
+          "version": "^2.0.0",
+          "methods": {
+            "brokeredMethod1": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/happner-cluster/test/_lib/integration-37-remote-component/index.js
+++ b/packages/happner-cluster/test/_lib/integration-37-remote-component/index.js
@@ -1,0 +1,16 @@
+module.exports = Component;
+
+function Component() {}
+
+Component.prototype.start = function ($happn, callback) {
+  callback();
+};
+
+Component.prototype.stop = function ($happn, callback) {
+  callback();
+};
+
+Component.prototype.brokeredMethod1 = function ($happn, callback) {
+  callback(null, $happn.info.mesh.name + ':remoteComponent:brokeredMethod1');
+};
+

--- a/packages/happner-cluster/test/_lib/integration-37-remote-component/package.json
+++ b/packages/happner-cluster/test/_lib/integration-37-remote-component/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "remote-component",
+  "version": "2.2.0"
+}

--- a/packages/happner-cluster/test/integration/37-nodes-rejoin-when-connection-breaks.js
+++ b/packages/happner-cluster/test/integration/37-nodes-rejoin-when-connection-breaks.js
@@ -1,0 +1,71 @@
+const libDir = require('../_lib/lib-dir');
+const baseConfig = require('../_lib/base-config');
+const users = require('../_lib/users');
+const testclient = require('../_lib/client');
+const getSeq = require('../_lib/helpers/getSeq');
+const clusterHelper = require('../_lib/helpers/muliProcessClusterManager').create();
+
+const clearMongoCollection = require('../_lib/clear-mongo-collection');
+
+require('../_lib/test-helper').describe({ timeout: 120e3 }, (test) => {
+  let _AdminClient;
+  let testClient;
+
+  before('clear mongo collection', (done) => {
+    clearMongoCollection('mongodb://localhost', 'happn-cluster', done);
+  });
+  before('start cluster', async () => {
+    const serverPromises = [];
+    const remoteComponent = baseConfig(getSeq.getFirst(), 2, true, null, null, null, null, null);
+    remoteComponent.modules = {
+      remoteComponent: {
+        path: libDir + 'integration-37-remote-component',
+      },
+    };
+    remoteComponent.components = {
+      remoteComponent: {
+        startMethod: 'start',
+        stopMethod: 'stop',
+      },
+    };
+    serverPromises.push(clusterHelper.start(remoteComponent));
+    const brokerComponent = baseConfig(getSeq.getNext(), 2, true, null, null, null, null, null);
+    brokerComponent.modules = {
+      brokerComponent: {
+        path: libDir + 'integration-37-broker-component',
+      },
+    };
+    brokerComponent.components = {
+      brokerComponent: {
+        startMethod: 'start',
+        stopMethod: 'stop',
+      },
+    };
+    serverPromises.push(clusterHelper.start(brokerComponent));
+    return Promise.all(serverPromises);
+  });
+  before('creat test clients client', async () => {
+    _AdminClient = await testclient.create('_ADMIN', 'happn', getSeq.getPort(1));
+    await users.add(_AdminClient, 'username', 'password');
+    await users.allowMethod(_AdminClient, 'username', 'brokerComponent', 'block');
+    await users.allowMethod(_AdminClient, 'username', 'remoteComponent', 'brokeredMethod1');
+    testClient = await testclient.create('username', 'password', getSeq.getPort(2));
+  });
+  after('disconnect _ADMIN client', async () => {
+    await _AdminClient.disconnect();
+    await testClient.disconnect();
+    _AdminClient = null;
+    testClient = null;
+  });
+
+  after('stop cluster', async () => {
+    await clusterHelper.destroy();
+  });
+
+  it('broker rejoins cluster after event loop block causes it to disconnect', async () => {
+    await testClient.exchange.brokerComponent.block();
+    await test.delay(15000); //wait for component to stop blocking and reconnect to mesh
+    let result = await testClient.exchange.remoteComponent.brokeredMethod1(); //mesh deemed healthy if function can be called through mesh
+    test.expect(result).to.be(getSeq.getMeshName(1) + ':remoteComponent:brokeredMethod1');
+  });
+});


### PR DESCRIPTION
SMCC-428 remove cluster member from service entry when orchestrator kills member.
Bug caused by the fact the Orchestrator class can mutate cluster members but its not the owner of cluster members.