### PR TITLE
fix/TEN-49-persisted-cache-ttl-during-sync

### DIFF
--- a/packages/happn-3/lib/services/cache/cache-persist.js
+++ b/packages/happn-3/lib/services/cache/cache-persist.js
@@ -1,5 +1,6 @@
 module.exports = class CachePersist extends require('./cache-static') {
   #synced = false;
+  #syncing = false;
   #dataStore;
   #basePath;
   constructor(name, opts) {
@@ -46,7 +47,7 @@ module.exports = class CachePersist extends require('./cache-static') {
       callback = opts;
       opts = {};
     }
-    if (!this.#checkSynced(callback)) {
+    if (!this.#syncing && !this.#checkSynced(callback)) {
       return;
     }
 
@@ -54,7 +55,7 @@ module.exports = class CachePersist extends require('./cache-static') {
     if (!opts.ttl) opts.ttl = this.opts.defaultTTL;
     if (opts.noPersist) {
       const result = super.set(key, data, opts);
-      callback(null, result);
+      return callback(null, result);
     }
 
     this.#persistData(key, this.createCacheItem(key, data, opts), (e) => {
@@ -126,6 +127,7 @@ module.exports = class CachePersist extends require('./cache-static') {
   }
 
   sync(callback) {
+    this.#syncing = true;
     this.#dataStore.get(`${this.#basePath}/*`, (e, items) => {
       if (e) return callback(e);
 
@@ -142,7 +144,6 @@ module.exports = class CachePersist extends require('./cache-static') {
               return this.#removeData(item.data.key, itemCB);
             }
           }
-
           this.set(
             item.data.key,
             item.data.data,
@@ -154,6 +155,7 @@ module.exports = class CachePersist extends require('./cache-static') {
           );
         },
         (e) => {
+          this.#syncing = false;
           if (e) return callback(e);
           this.#synced = true;
           callback();

--- a/packages/happn-3/test/integration/security/token-revocations.js
+++ b/packages/happn-3/test/integration/security/token-revocations.js
@@ -1,39 +1,122 @@
-describe(
-  require('../../__fixtures/utils/test_helper').create().testName(__filename, 3),
-  function () {
-    this.timeout(30000);
-    const delay = require('await-delay');
-    const request = require('request');
-    const expect = require('expect.js');
-    const happn = require('../../../lib/index');
-    const service = happn.service;
+require('../../__fixtures/utils/test_helper').describe({ timeout: 120e3 }, function (test) {
+  const request = require('request');
+  const happn = require('../../../lib/index');
+  const service = happn.service;
 
-    const serverConfig = {
-      secure: true,
-      services: {
-        security: {
-          config: {
-            sessionTokenSecret: 'h1_test-secret',
-            profiles: [
-              {
-                name: 'short-session',
-                session: {
-                  'user.username': {
-                    $eq: 'user-short-session',
-                  },
-                },
-                policy: {
-                  ttl: '2 seconds',
+  const serverConfig = {
+    secure: true,
+    services: {
+      security: {
+        config: {
+          sessionTokenSecret: 'h1_test-secret',
+          profiles: [
+            {
+              name: 'short-session',
+              session: {
+                'user.username': {
+                  $eq: 'user-short-session',
                 },
               },
-            ],
-          },
+              policy: {
+                ttl: '2 seconds',
+              },
+            },
+          ],
         },
       },
-    };
+    },
+  };
 
-    it('logs in with a stateless (web based) request, we revoke the token and ensure the revocation expires with the token ttl', async () => {
-      const server = await getServer(serverConfig);
+  it('logs in with a stateless (web based) request, we revoke the token and ensure the revocation expires with the token ttl', async () => {
+    const server = await getServer(serverConfig);
+
+    await upsertUser(server, {
+      username: 'user-short-session',
+      password: 'user-short-session-password',
+    });
+
+    const result = await doRequest(
+      '/auth/login?username=user-short-session&password=user-short-session-password',
+      null,
+      true
+    );
+    const token = JSON.parse(result.body).data;
+    test.expect(token != null).to.be(true);
+    await revokeToken(server, token);
+    let revocation = await server.services.security.__cache_revoked_tokens.get(token);
+    delete revocation.timestamp;
+    test.expect(revocation).to.eql({
+      reason: 'test reason',
+      ttl: 2000,
+    });
+    await test.delay(3000);
+    let revocationCheckedAgain = await server.services.security.__cache_revoked_tokens.get(token);
+    test.expect(revocationCheckedAgain).to.eql(null);
+    stopServer(server);
+  });
+
+  it('logs in with a stateful request, then does a series of logins with with the original token, we revoke the token and ensure all children sessions have been disconnected', async () => {
+    const server = await getServer(serverConfig);
+    await upsertUser(server, {
+      username: 'user-short-session',
+      password: 'user-short-session-password',
+    });
+    const client1 = await getClient({
+      username: 'user-short-session',
+      password: 'user-short-session-password',
+    });
+    const clientsSessionEvents = {};
+    client1.onEvent('session-ended', (evt) => {
+      clientsSessionEvents['session-ended-1'] = evt;
+    });
+    const client2 = await getClient({
+      username: 'user-short-session',
+      token: client1.session.token,
+    });
+    client2.onEvent('session-ended', (evt) => {
+      clientsSessionEvents['session-ended-2'] = evt;
+    });
+    const client3 = await getClient({
+      username: 'user-short-session',
+      token: client1.session.token,
+    });
+    client3.onEvent('session-ended', (evt) => {
+      clientsSessionEvents['session-ended-3'] = evt;
+    });
+    const client4 = await getClient({
+      username: 'user-short-session',
+      token: client1.session.token,
+    });
+    client4.onEvent('session-ended', (evt) => {
+      clientsSessionEvents['session-ended-4'] = evt;
+    });
+
+    await revokeToken(server, client1.session.token);
+    await test.delay(1000);
+
+    test.expect(clientsSessionEvents).to.eql({
+      'session-ended-1': {
+        reason: 'token-revoked',
+      },
+      'session-ended-2': {
+        reason: 'token-revoked',
+      },
+      'session-ended-3': {
+        reason: 'token-revoked',
+      },
+      'session-ended-4': {
+        reason: 'token-revoked',
+      },
+    });
+    stopServer(server);
+  });
+
+  it('logs in with a stateless (web based) request, we revoke the token and ensure the revocation expires with the token ttl', async () => {
+    const filename = `${test.tempDirectory()}/token-revocations.loki`;
+    try {
+      tryUnlink(filename);
+      const fileConfig = { services: { data: { config: { filename } } } };
+      let server = await getServer(test.commons._.merge(serverConfig, fileConfig));
 
       await upsertUser(server, {
         username: 'user-short-session',
@@ -46,137 +129,91 @@ describe(
         true
       );
       const token = JSON.parse(result.body).data;
-      expect(token != null).to.be(true);
+      test.expect(token != null).to.be(true);
       await revokeToken(server, token);
-      let revocation = await server.services.security.__cache_revoked_tokens.get(token);
-      delete revocation.timestamp;
-      expect(revocation).to.eql({
-        reason: 'test reason',
-        ttl: 2000,
-      });
-      await delay(3000);
+      stopServer(server);
+      await test.delay(4e3);
+      // restart the server - there should be a timed out revocation in the db
+      server = await getServer(test.commons._.merge(serverConfig, fileConfig));
       let revocationCheckedAgain = await server.services.security.__cache_revoked_tokens.get(token);
-      expect(revocationCheckedAgain).to.eql(null);
+      test.expect(revocationCheckedAgain).to.eql(null);
       stopServer(server);
-    });
-
-    it('logs in with a stateful request, then does a series of logins with with the original token, we revoke the token and ensure all children sessions have been disconnected', async () => {
-      const server = await getServer(serverConfig);
-      await upsertUser(server, {
-        username: 'user-short-session',
-        password: 'user-short-session-password',
-      });
-      const client1 = await getClient({
-        username: 'user-short-session',
-        password: 'user-short-session-password',
-      });
-      const clientsSessionEvents = {};
-      client1.onEvent('session-ended', (evt) => {
-        clientsSessionEvents['session-ended-1'] = evt;
-      });
-      const client2 = await getClient({
-        username: 'user-short-session',
-        token: client1.session.token,
-      });
-      client2.onEvent('session-ended', (evt) => {
-        clientsSessionEvents['session-ended-2'] = evt;
-      });
-      const client3 = await getClient({
-        username: 'user-short-session',
-        token: client1.session.token,
-      });
-      client3.onEvent('session-ended', (evt) => {
-        clientsSessionEvents['session-ended-3'] = evt;
-      });
-      const client4 = await getClient({
-        username: 'user-short-session',
-        token: client1.session.token,
-      });
-      client4.onEvent('session-ended', (evt) => {
-        clientsSessionEvents['session-ended-4'] = evt;
-      });
-
-      await revokeToken(server, client1.session.token);
-      await delay(1000);
-
-      expect(clientsSessionEvents).to.eql({
-        'session-ended-1': {
-          reason: 'token-revoked',
-        },
-        'session-ended-2': {
-          reason: 'token-revoked',
-        },
-        'session-ended-3': {
-          reason: 'token-revoked',
-        },
-        'session-ended-4': {
-          reason: 'token-revoked',
-        },
-      });
-      stopServer(server);
-    });
-
-    function upsertUser(server, user) {
-      return new Promise((resolve, reject) => {
-        server.services.security.users.upsertUser(user, (e, upserted) => {
-          if (e) return reject(e);
-          resolve(upserted);
-        });
-      });
+    } finally {
+      tryUnlink(filename);
     }
+  });
 
-    function getServer(config) {
-      return new Promise((resolve, reject) => {
-        service.create(config, function (e, instance) {
-          if (e) return reject(e);
-          resolve(instance);
-        });
-      });
-    }
-
-    function stopServer(server) {
-      return new Promise((resolve, reject) => {
-        server.stop((e) => {
-          if (e) return reject(e);
-          resolve();
-        });
-      });
-    }
-
-    function getClient(config) {
-      return new Promise((resolve, reject) => {
-        happn.client.create(config, (e, instance) => {
-          if (e) return reject(e);
-          resolve(instance);
-        });
-      });
-    }
-
-    function revokeToken(server, token) {
-      return new Promise((resolve, reject) => {
-        server.services.security.revokeToken(token, 'test reason', (e) => {
-          if (e) return reject(e);
-          resolve();
-        });
-      });
-    }
-
-    function doRequest(path, body, token) {
-      var options = {
-        url: 'http://127.0.0.1:55000' + path,
-      };
-
-      if (!token) options.url += '?happn_token=' + token;
-
-      return new Promise((resolve, reject) => {
-        request(options, function (error, response, body) {
-          if (error) return reject(error);
-          resolve({
-            response,
-            body,
-          });
-        });
-      });
+  function tryUnlink(filename) {
+    try {
+      test.commons.fs.unlinkSync(filename);
+      test.commons.fs.unlinkSync(
+        filename.replace('token-revocations.loki', 'temp_token-revocations.loki')
+      );
+    } catch (_e) {
+      //do nothing
     }
   }
-);
+
+  function upsertUser(server, user) {
+    return new Promise((resolve, reject) => {
+      server.services.security.users.upsertUser(user, (e, upserted) => {
+        if (e) return reject(e);
+        resolve(upserted);
+      });
+    });
+  }
+
+  function getServer(config) {
+    return new Promise((resolve, reject) => {
+      service.create(config, function (e, instance) {
+        if (e) return reject(e);
+        resolve(instance);
+      });
+    });
+  }
+
+  function stopServer(server) {
+    return new Promise((resolve, reject) => {
+      server.stop((e) => {
+        if (e) return reject(e);
+        resolve();
+      });
+    });
+  }
+
+  function getClient(config) {
+    return new Promise((resolve, reject) => {
+      happn.client.create(config, (e, instance) => {
+        if (e) return reject(e);
+        resolve(instance);
+      });
+    });
+  }
+
+  function revokeToken(server, token) {
+    return new Promise((resolve, reject) => {
+      server.services.security.revokeToken(token, 'test reason', (e) => {
+        if (e) return reject(e);
+        resolve();
+      });
+    });
+  }
+
+  function doRequest(path, body, token) {
+    var options = {
+      url: 'http://127.0.0.1:55000' + path,
+    };
+
+    if (!token) options.url += '?happn_token=' + token;
+
+    return new Promise((resolve, reject) => {
+      request(options, function (error, response, body) {
+        if (error) return reject(error);
+        resolve({
+          response,
+          body,
+        });
+      });
+    });
+  }
+});

--- a/packages/happn-db-provider-loki/test/integration/index.js
+++ b/packages/happn-db-provider-loki/test/integration/index.js
@@ -266,6 +266,7 @@ require('happn-commons-test').describe({ timeout: 20e3 }, (test) => {
     };
     await lokiProvider.initialize();
     await lokiProvider.insert({ path: 'test/path/1', data: { test: 'test' } });
+    const found1 = (await lokiProvider.find('test/path/1'))[0];
     await lokiProvider.insert({ path: 'test/path/2', data: { test: 'test' } });
     await lokiProvider.insert({ path: 'test/path/3', data: { test: 'test' } });
     let found = await lokiProvider.find('test/path/*');
@@ -293,6 +294,9 @@ require('happn-commons-test').describe({ timeout: 20e3 }, (test) => {
     test.expect(lokiProvider.operationCount).to.be(3);
     await lokiProvider.stop();
     await lokiProvider.initialize();
+    const found1Again = (await lokiProvider.find('test/path/1'))[0];
+    test.expect(found1Again.created).to.eql(found1.created);
+    test.expect(found1Again.modified).to.eql(found1.modified);
     found = await lokiProvider.find('test/path/*');
     test.expect(found.length).to.be(3);
     test.expect(lokiProvider.operationCount).to.be(0);


### PR DESCRIPTION
TEN-49: updated loki to not mutate created modified on rebuild, fixed persisted cache to allow sets whilst syncing